### PR TITLE
feat: transform errors before reporting to Sentry

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,13 @@ module.exports = class ServerTransport extends Transport {
         });
 
         if (info.level === 'error') {
-            Sentry.captureException(info[Symbol.for('message')]);
+            if (info.message.error && info.message.error instanceof Error) {
+                Sentry.captureException(info.message.error);
+            } else {
+                const error = new Error(info.message)
+                error.data = info[Symbol.for('message')]
+                Sentry.captureException(error);
+            }
         }
 
         if (info.level === 'warn') {
@@ -32,6 +38,3 @@ module.exports = class ServerTransport extends Transport {
         callback();
     }
 };
-
-
-


### PR DESCRIPTION
Do some handling of errors before reporting to error
If an object is passed to the Sentry `captureException` they create a SyntheticException or something similar. It's nicer if we report an error object directly.